### PR TITLE
Dockerfile optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@(-.-)/env": "0.3.2",
     "@keyv/sqlite": "3.6.5",
     "discord.js": "14.11.0",
+    "dotenv": "16.0.3",
     "glob": "^10.2.4",
     "keyv": "4.5.2",
     "zod": "3.21.4"
@@ -27,7 +28,6 @@
     "@types/node": "18.16.7",
     "@typescript-eslint/eslint-plugin": "5.59.6",
     "@typescript-eslint/parser": "5.59.6",
-    "dotenv": "16.0.3",
     "eslint": "8.40.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-plugin-import": "2.27.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ dependencies:
   discord.js:
     specifier: 14.11.0
     version: 14.11.0
+  dotenv:
+    specifier: 16.0.3
+    version: 16.0.3
   glob:
     specifier: ^10.2.4
     version: 10.2.4
@@ -39,9 +42,6 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: 5.59.6
     version: 5.59.6(eslint@8.40.0)(typescript@5.0.4)
-  dotenv:
-    specifier: 16.0.3
-    version: 16.0.3
   eslint:
     specifier: 8.40.0
     version: 8.40.0
@@ -1232,7 +1232,7 @@ packages:
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
-    dev: true
+    dev: false
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}


### PR DESCRIPTION
# Description

Current Dockerfile image is massive. This is because of layer sizes produced by installing all dependencies including `devDependencies`.

tl;dr change Dockerfile to be multi-stage build only include what *actually* needs to run on production with OS mostly stripped out.

Total image size gone down from **446MB** to **188MB**

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor or other

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
