### PR TITLE
fix cannot read commands on windows

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -38,12 +38,16 @@ export default class Bot extends Client {
 
   async handler() {
     console.info('[HANDLER] Loading...')
-    const eventFiles = globSync(
-      path.resolve(this.__dirname, 'events/*.{js,ts}'),
-    )
-    const commandFolders = globSync(
-      path.resolve(this.__dirname, 'commands/**/*.{js,ts}'),
-    )
+    const eventFiles = globSync('events/*.{js,ts}', {
+      cwd: this.__dirname,
+      root: this.__dirname,
+      absolute: true,
+    })
+    const commandFolders = globSync('commands/**/*.{js,ts}', {
+      cwd: this.__dirname,
+      root: this.__dirname,
+      absolute: true,
+    })
     void this.handleEvents(eventFiles)
     void this.handleCommands(commandFolders)
     return Promise.resolve(true)
@@ -53,7 +57,7 @@ export default class Bot extends Client {
     for (const file of eventFiles) {
       if (!file[0].startsWith('-')) {
         try {
-          const eventHandlerConfig = await import(`${file}`).then(
+          const eventHandlerConfig = await import(`file:///${file}`).then(
             ({ default: defaultExport }) => defaultExport,
           )
 
@@ -80,7 +84,7 @@ export default class Bot extends Client {
     for (const cmdfile of commandFiles) {
       if (!cmdfile[0].startsWith('-')) {
         try {
-          const commandHandlerConfig = await import(`${cmdfile}`).then(
+          const commandHandlerConfig = await import(`file:///${cmdfile}`).then(
             ({ default: defaultExport }) => defaultExport,
           )
 


### PR DESCRIPTION
# Description

Fix so it can read command on windows (in case we have contributor using windows), while still work on linux. I don't have macos but I guess it still work.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
