### PR TITLE
make ping command ephemeral

### DIFF
--- a/src/commands/info/ping.ts
+++ b/src/commands/info/ping.ts
@@ -5,6 +5,7 @@ export default {
     name: 'ping',
     description: 'Ping!',
   },
+  ephemeral: true,
   execute: async (client, interaction) => {
     await interaction.editReply({
       embeds: [

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -6,16 +6,6 @@ export default {
   execute: async (client, interaction) => {
     if (interaction.isCommand()) {
       const commandName = interaction.commandName
-
-      // Warning: Shit code
-      if (commandName === 'Report to mod') {
-        await interaction.reply({
-          ephemeral: true,
-          content: 'Ok, reported, kthx',
-        })
-        return
-      }
-
       const command = client.commands.get(commandName)
       if (!command) return
       let bypass = true


### PR DESCRIPTION
# Description

Right now the `/ping` command posts the result to the server. This can be annoying.

Also removed shit code made earlier lol

## Screenshot

1st message is before
2nd message is after

<img width="337" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/b6ec0408-5ea3-428e-89dd-a2b086b77e81">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
