### PR TITLE
use guild commands instead of global application commands

### DIFF
--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,19 +1,38 @@
 import { Events } from 'discord.js'
 
+import { Environment } from '../config.js'
 import { EventHandlerConfig } from '../types/EventHandlerConfig.js'
 
 export default {
   eventName: Events.ClientReady,
   once: true,
   execute: async (client) => {
-    console.log(`Helloworld, Online as ${client.user?.tag}.`)
+    console.log(`[ready] Now online as ${client.user?.tag}.`)
     const commands_data = [...client.commands.values()].map(
       (command) => command.data,
     )
+
+    // Set guild commands
     try {
-      await client.application?.commands.set(commands_data)
+      const guild = client.guilds.cache.get(Environment.GUILD_ID)
+      if (!guild) {
+        throw new Error(`Guild ${Environment.GUILD_ID} not found`)
+      }
+      await guild.commands.set(commands_data)
+      console.info(`[ready] Guild commands registered on ${guild.name}`)
     } catch (error) {
-      console.log(error)
+      console.error('[ready] Unable to set guild commands:', error)
+    }
+
+    // Clear global commands
+    try {
+      const commands = await client.application?.commands.fetch()
+      for (const command of commands?.values() || []) {
+        await command.delete()
+        console.info(`[ready] Deleted global command ${command.name}`)
+      }
+    } catch (error) {
+      console.error('[ready] Unable to clear application commands:', error)
     }
   },
 } satisfies EventHandlerConfig<Events.ClientReady>


### PR DESCRIPTION
# Description

global application commands are cached for 1 hour. this makes it janky to update. guild commands update immediately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
