### PR TITLE
ci: Using concurrency to cancel any in-progress job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,9 @@ on:
   merge_group:
   push:
     branches: [main]
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   lint-checks:
     name: Check ESLint and Format

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+yarn.lock
 
 dist
 


### PR DESCRIPTION
# Description

- Using concurrency in CI to cancel any in-progress job to run as a higher-priority waiting request.
- ignore yarn.lock

## Type of change

Please delete options that are not relevant.
- [x] Refactor or other

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
