### PR TITLE
‍profile inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
-    "generate:prisma": "prisma generate"
+    "generate:prisma": "prisma generate",
+    "migrate": "prisma db push"
   },
   "dependencies": {
     "@(-.-)/env": "0.3.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,3 +46,24 @@ model MessageReport {
   @@index([reporterId])
   @@index([reporteeId])
 }
+
+model UserModerationLog {
+  id       String @id @default(uuid())
+  userId   String
+  actorId  String
+  type     String
+  message  String
+  metadata String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId, createdAt])
+}
+
+model UserProfile {
+  id          String @id
+  tag         String
+  displayName String
+  strikes     Int    @default(0)
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,7 @@
 import ping from './info/ping.js'
 import deleteAllMessage from './moderators/deleteAllMessage.js'
+import inspectProfile from './moderators/inspectProfile.js'
 import report from './moderators/report.js'
 import user from './moderators/user.js'
 
-export default [ping, deleteAllMessage, report, user]
+export default [ping, deleteAllMessage, inspectProfile, report, user]

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,4 +4,4 @@ import inspectProfile from './moderators/inspectProfile.js'
 import report from './moderators/report.js'
 import user from './moderators/user.js'
 
-export default [ping, deleteAllMessage, inspectProfile, report, user]
+export default [ping, deleteAllMessage, ...inspectProfile, report, user]

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,7 +1,15 @@
+import { CommandHandlerConfig } from '../types/CommandHandlerConfig.js'
+
 import ping from './info/ping.js'
 import deleteAllMessage from './moderators/deleteAllMessage.js'
 import inspectProfile from './moderators/inspectProfile.js'
 import report from './moderators/report.js'
 import user from './moderators/user.js'
 
-export default [ping, deleteAllMessage, ...inspectProfile, report, user]
+export default [
+  ping,
+  deleteAllMessage,
+  ...inspectProfile,
+  report,
+  user,
+] satisfies CommandHandlerConfig[]

--- a/src/commands/moderators/inspectProfile.ts
+++ b/src/commands/moderators/inspectProfile.ts
@@ -28,7 +28,7 @@ export default [
   },
   {
     data: {
-      name: 'Inspect author profile',
+      name: 'Inspect author',
       type: ApplicationCommandType.Message,
       defaultMemberPermissions: PermissionsBitField.Flags.ManageMessages,
       dmPermission: false,

--- a/src/commands/moderators/inspectProfile.ts
+++ b/src/commands/moderators/inspectProfile.ts
@@ -23,7 +23,7 @@ export default [
       const member = interaction.guild.members.cache.get(userId)
       if (!member) return
 
-      await inspectProfile(client, interaction, member)
+      await inspectProfile({ client, interaction, member })
     },
   },
   {
@@ -45,7 +45,12 @@ export default [
       const member = interaction.guild.members.cache.get(userId)
       if (!member) return
 
-      await inspectProfile(client, interaction, member, message)
+      await inspectProfile({
+        client,
+        interaction,
+        member,
+        messageContext: message,
+      })
     },
   },
   {
@@ -71,7 +76,7 @@ export default [
       const member = interaction.guild.members.cache.get(userId)
       if (!member) return
 
-      await inspectProfile(client, interaction, member)
+      await inspectProfile({ client, interaction, member })
     },
   },
 ] satisfies CommandHandlerConfig[]

--- a/src/commands/moderators/inspectProfile.ts
+++ b/src/commands/moderators/inspectProfile.ts
@@ -1,23 +1,77 @@
-import { ApplicationCommandType, PermissionsBitField } from 'discord.js'
+import {
+  ApplicationCommandOptionType,
+  ApplicationCommandType,
+  PermissionsBitField,
+} from 'discord.js'
 
 import { inspectProfile } from '../../features/profileInspector/index.js'
 import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
 
-export default {
-  data: {
-    name: 'Inspect profile',
-    type: ApplicationCommandType.User,
-    defaultMemberPermissions: PermissionsBitField.Flags.ManageChannels,
-    dmPermission: false,
-  },
-  ephemeral: true,
-  execute: async (client, interaction) => {
-    if (!interaction.guild || !interaction.isContextMenuCommand()) return
+export default [
+  {
+    data: {
+      name: 'Inspect profile',
+      type: ApplicationCommandType.User,
+      defaultMemberPermissions: PermissionsBitField.Flags.ManageMessages,
+      dmPermission: false,
+    },
+    ephemeral: true,
+    execute: async (client, interaction) => {
+      if (!interaction.guild || !interaction.isContextMenuCommand()) return
 
-    const userId = interaction.targetId
-    const member = interaction.guild.members.cache.get(userId)
-    if (!member) return
+      const userId = interaction.targetId
+      const member = interaction.guild.members.cache.get(userId)
+      if (!member) return
 
-    await inspectProfile(client, interaction, member)
+      await inspectProfile(client, interaction, member)
+    },
   },
-} satisfies CommandHandlerConfig
+  {
+    data: {
+      name: 'Inspect author profile',
+      type: ApplicationCommandType.Message,
+      defaultMemberPermissions: PermissionsBitField.Flags.ManageMessages,
+      dmPermission: false,
+    },
+    ephemeral: true,
+    execute: async (client, interaction) => {
+      if (!interaction.guild || !interaction.isContextMenuCommand()) return
+
+      const messageId = interaction.targetId
+      const message = await interaction.channel?.messages.fetch(messageId)
+      if (!message) return
+
+      const userId = message.author.id
+      const member = interaction.guild.members.cache.get(userId)
+      if (!member) return
+
+      await inspectProfile(client, interaction, member, message)
+    },
+  },
+  {
+    data: {
+      name: 'inspect',
+      description: 'Inspect a user profile',
+      defaultMemberPermissions: PermissionsBitField.Flags.ManageMessages,
+      type: ApplicationCommandType.ChatInput,
+      options: [
+        {
+          name: 'user',
+          description: 'The user to inspect',
+          type: ApplicationCommandOptionType.User,
+        },
+      ],
+    },
+    ephemeral: true,
+    execute: async (client, interaction) => {
+      if (!interaction.guild || !interaction.isChatInputCommand()) return
+
+      const userId = interaction.options.getUser('user')?.id
+      if (!userId) return
+      const member = interaction.guild.members.cache.get(userId)
+      if (!member) return
+
+      await inspectProfile(client, interaction, member)
+    },
+  },
+] satisfies CommandHandlerConfig[]

--- a/src/commands/moderators/inspectProfile.ts
+++ b/src/commands/moderators/inspectProfile.ts
@@ -1,0 +1,23 @@
+import { ApplicationCommandType, PermissionsBitField } from 'discord.js'
+
+import { inspectProfile } from '../../features/profileInspector/index.js'
+import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
+
+export default {
+  data: {
+    name: 'Inspect profile',
+    type: ApplicationCommandType.User,
+    defaultMemberPermissions: PermissionsBitField.Flags.ManageChannels,
+    dmPermission: false,
+  },
+  ephemeral: true,
+  execute: async (client, interaction) => {
+    if (!interaction.guild || !interaction.isContextMenuCommand()) return
+
+    const userId = interaction.targetId
+    const member = interaction.guild.members.cache.get(userId)
+    if (!member) return
+
+    await inspectProfile(client, interaction, member)
+  },
+} satisfies CommandHandlerConfig

--- a/src/commands/moderators/user.ts
+++ b/src/commands/moderators/user.ts
@@ -4,7 +4,7 @@ import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
 
 export default {
   data: {
-    name: 'user',
+    name: 'Show user info',
     type: ApplicationCommandType.User,
   },
   ephemeral: true,

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,5 +1,11 @@
+import { AnyEventHandlerConfig } from '../types/EventHandlerConfig.js'
+
 import interactionCreate from './interactionCreate.js'
 import preventEmojiSpam from './preventEmojiSpam.js'
 import ready from './ready.js'
 
-export default [interactionCreate, preventEmojiSpam, ready]
+export default [
+  interactionCreate,
+  preventEmojiSpam,
+  ready,
+] satisfies AnyEventHandlerConfig[]

--- a/src/features/profileInspector/index.ts
+++ b/src/features/profileInspector/index.ts
@@ -32,7 +32,9 @@ export async function inspectProfile(
   return inspectProfileMain({ options })
 }
 
-async function inspectProfileMain(context: InspectProfileContext) {
+async function inspectProfileMain(
+  context: InspectProfileContext,
+): Promise<void> {
   const { interaction, member, messageContext } = context.options
   const logs = await prisma.userModerationLog.findMany({
     where: { userId: member.user.id },

--- a/src/features/profileInspector/index.ts
+++ b/src/features/profileInspector/index.ts
@@ -1,0 +1,207 @@
+import {
+  APIEmbed,
+  ButtonStyle,
+  Client,
+  CommandInteraction,
+  ComponentType,
+  GuildMember,
+} from 'discord.js'
+import { InteractionButtonComponentData } from 'discord.js'
+import { TextInputStyle } from 'discord.js'
+
+import { UserModerationLog } from '@prisma/client'
+import { randomUUID } from 'crypto'
+
+import { prisma } from '../../prisma.js'
+
+export async function inspectProfile(
+  client: Client,
+  interaction: CommandInteraction,
+  member: GuildMember,
+): Promise<void> {
+  const logs = await prisma.userModerationLog.findMany({
+    where: { userId: member.user.id },
+    orderBy: { createdAt: 'desc' },
+    take: 5,
+  })
+  const userProfile = await ensureUserProfile(member)
+
+  const description =
+    logs.length > 0
+      ? logs.map(formatLog).join('\n')
+      : '(No moderation logs found)'
+
+  const embeds: APIEmbed[] = [
+    {
+      title: `${userProfile.tag} (${userProfile.displayName})`,
+      description,
+      color: 0xff7700,
+      fields: [
+        { name: 'ID', value: userProfile.id, inline: true },
+        { name: 'Strikes', value: `${userProfile.strikes}`, inline: true },
+      ],
+    },
+  ]
+
+  const strikeActionId = randomUUID() as string
+  const resetStrikeActionId = randomUUID() as string
+  const buttons: InteractionButtonComponentData[] = []
+  buttons.push({
+    type: ComponentType.Button,
+    style: ButtonStyle.Primary,
+    label: 'Strike',
+    customId: strikeActionId,
+  })
+  if (userProfile.strikes > 0) {
+    buttons.push({
+      type: ComponentType.Button,
+      style: ButtonStyle.Primary,
+      label: 'Reset strike',
+      customId: resetStrikeActionId,
+    })
+  }
+  await interaction.editReply({
+    embeds,
+    components: [
+      {
+        type: ComponentType.ActionRow,
+        components: buttons,
+      },
+    ],
+  })
+
+  const selectedInteraction = await Promise.resolve(
+    interaction.channel?.awaitMessageComponent({
+      filter: (i) => buttons.map((b) => b.customId).includes(i.customId),
+      time: 60000,
+    }),
+  ).catch(() => null)
+
+  if (!selectedInteraction) {
+    await interaction.editReply({ components: [] })
+    return
+  }
+
+  const logActivity = (
+    type: string,
+    message: string,
+    metadata: object = {},
+  ) => {
+    return prisma.userModerationLog.create({
+      data: {
+        userId: userProfile.id,
+        actorId: interaction.user.id,
+        type,
+        message,
+        metadata: JSON.stringify(metadata),
+      },
+    })
+  }
+
+  if (selectedInteraction.customId === strikeActionId) {
+    const strikes = userProfile.strikes + 1
+    const promptId = randomUUID() as string
+    await selectedInteraction.showModal({
+      customId: promptId,
+      title: `Strike #${strikes}`,
+      components: [
+        {
+          type: ComponentType.ActionRow,
+          components: [
+            {
+              customId: 'reason',
+              label: 'Reason',
+              type: ComponentType.TextInput,
+              style: TextInputStyle.Short,
+              required: true,
+              placeholder: '…',
+            },
+          ],
+        },
+      ],
+    })
+    const submitted = await selectedInteraction
+      .awaitModalSubmit({
+        time: 5 * 60000,
+        filter: (i) => i.customId === promptId,
+      })
+      .catch(() => null)
+    if (!submitted) {
+      await selectedInteraction.reply({
+        content: 'Timed out',
+        ephemeral: true,
+      })
+      return inspectProfile(client, interaction, member)
+    }
+
+    const reason = submitted.fields.getTextInputValue('reason')
+    await prisma.userProfile.update({
+      where: { id: userProfile.id },
+      data: { strikes },
+    })
+    await logActivity(
+      'strike',
+      `strike #${strikes} added by ${interaction.user.tag}: ${reason}`,
+      { strikes },
+    )
+
+    await submitted.reply({
+      content: `strike #${strikes} added to ${userProfile.tag}`,
+      ephemeral: true,
+    })
+    return inspectProfile(client, interaction, member)
+  }
+
+  if (selectedInteraction.customId === resetStrikeActionId) {
+    await prisma.userProfile.update({
+      where: { id: userProfile.id },
+      data: { strikes: 0 },
+    })
+    await logActivity(
+      'strike',
+      `strikes reset to 0 by ${interaction.user.tag}`,
+      { strikes: 0 },
+    )
+    await selectedInteraction.reply({
+      content: `strikes reset for ${userProfile.tag}`,
+      ephemeral: true,
+    })
+    return inspectProfile(client, interaction, member)
+  }
+}
+
+const formatLog = (log: UserModerationLog) =>
+  `${formatDiscordTimestamp(log.createdAt)} ${log.type} - ${log.message}`
+
+const formatDiscordTimestamp = (date: Date) =>
+  `<t:${Math.floor(date.getTime() / 1000)}:R>`
+
+async function ensureUserProfile(member: GuildMember) {
+  const id = member.user.id
+  const tag = member.user.tag
+  const displayName = member.displayName
+  const userProfile = await prisma.userProfile.upsert({
+    where: { id: id },
+    update: { tag, displayName },
+    create: { id, tag, displayName },
+  })
+  return userProfile
+}
+
+export function addUserModerationLogEntry(
+  userId: string,
+  actorId: string,
+  type: string,
+  message: string,
+  metadata: object = {},
+) {
+  return prisma.userModerationLog.create({
+    data: {
+      userId,
+      actorId,
+      type,
+      message,
+      metadata: JSON.stringify(metadata),
+    },
+  })
+}

--- a/src/features/profileInspector/index.ts
+++ b/src/features/profileInspector/index.ts
@@ -15,12 +15,17 @@ import { randomUUID } from 'crypto'
 
 import { prisma } from '../../prisma.js'
 
+export interface InspectProfileOptions {
+  client: Client
+  interaction: CommandInteraction
+  member: GuildMember
+  messageContext?: Message
+}
+
 export async function inspectProfile(
-  client: Client,
-  interaction: CommandInteraction,
-  member: GuildMember,
-  messageContext?: Message,
+  options: InspectProfileOptions,
 ): Promise<void> {
+  const { client, interaction, member, messageContext } = options
   const logs = await prisma.userModerationLog.findMany({
     where: { userId: member.user.id },
     orderBy: { createdAt: 'desc' },

--- a/src/features/profileInspector/index.ts
+++ b/src/features/profileInspector/index.ts
@@ -22,10 +22,18 @@ export interface InspectProfileOptions {
   messageContext?: Message
 }
 
+interface InspectProfileContext {
+  options: InspectProfileOptions
+}
+
 export async function inspectProfile(
   options: InspectProfileOptions,
 ): Promise<void> {
-  const { client, interaction, member, messageContext } = options
+  return inspectProfileMain({ options })
+}
+
+async function inspectProfileMain(context: InspectProfileContext) {
+  const { interaction, member, messageContext } = context.options
   const logs = await prisma.userModerationLog.findMany({
     where: { userId: member.user.id },
     orderBy: { createdAt: 'desc' },
@@ -138,7 +146,7 @@ export async function inspectProfile(
         content: 'Timed out',
         ephemeral: true,
       })
-      return inspectProfile(client, interaction, member, messageContext)
+      return inspectProfileMain(context)
     }
 
     const reason = submitted.fields.getTextInputValue('reason')
@@ -158,7 +166,7 @@ export async function inspectProfile(
       content: `strike #${strikes} added to ${userProfile.tag}`,
       ephemeral: true,
     })
-    return inspectProfile(client, interaction, member, messageContext)
+    return inspectProfileMain(context)
   }
 
   if (selectedInteraction.customId === resetStrikeActionId) {
@@ -175,7 +183,7 @@ export async function inspectProfile(
       content: `strikes reset for ${userProfile.tag}`,
       ephemeral: true,
     })
-    return inspectProfile(client, interaction, member, messageContext)
+    return inspectProfileMain(context)
   }
 }
 

--- a/src/types/EventHandlerConfig.ts
+++ b/src/types/EventHandlerConfig.ts
@@ -9,3 +9,7 @@ export interface EventHandlerConfig<
   execute: EventHandlerExecutor<K>
   once?: boolean
 }
+
+// This is for use in an array, e.g. [...] satisfies AnyEventHandlerConfig[]
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyEventHandlerConfig = EventHandlerConfig<any>

--- a/src/utils/ActionSet.ts
+++ b/src/utils/ActionSet.ts
@@ -1,0 +1,71 @@
+import { MessageComponentInteraction, TextBasedChannel } from 'discord.js'
+
+import { randomUUID } from 'crypto'
+
+/**
+ * A utility class to help with the creation and execution of ephemeral actions.
+ *
+ * To use this class:
+ *
+ * 1. Create an instance of this class.
+ * 2. Register actions using {@link ActionSet.register}. This will return a custom ID that can be used in Discord message components.
+ * 3. Wait for an action using {@link ActionSet.awaitInChannel}.
+ */
+export class ActionSet<
+  THandler = (interaction: MessageComponentInteraction) => Promise<void>,
+> {
+  private map = new Map<string, RegisteredAction<THandler>>()
+
+  /**
+   * Registers an action.
+   * @param name - the name of the action, used for debugging
+   * @param handler - the action handler
+   * @returns a custom ID of the action that can be used in Discord
+   */
+  register(name: string, handler: THandler) {
+    const customId = randomUUID() as string
+    this.map.set(customId, { name, handler })
+    return customId
+  }
+
+  /**
+   * Resolves an action.
+   * @param thing - something that has a custom ID
+   */
+  resolve(thing?: { customId: string }) {
+    return thing ? this.map.get(thing.customId) : undefined
+  }
+
+  /**
+   * A filter function that can be passed to interaction collectors.
+   */
+  filter = ({ customId }: { customId: string }) => this.map.has(customId)
+
+  /**
+   * Waits for a registered action to occur in a channel.
+   * @param channel - the channel to wait for the action in
+   * @param timeout - the timeout in milliseconds
+   * @returns the interaction and the registered action, or undefined if the timeout was reached
+   */
+  awaitInChannel = async (
+    channel?: TextBasedChannel | null,
+    timeout = 60000,
+  ) => {
+    if (!channel) return undefined
+    const interaction = await channel
+      .awaitMessageComponent({
+        filter: this.filter,
+        time: timeout,
+      })
+      .catch(() => null)
+    if (!interaction) return undefined
+    const registeredAction = this.resolve(interaction)
+    if (!registeredAction) return undefined
+    return { interaction, registeredAction }
+  }
+}
+
+export interface RegisteredAction<T> {
+  name: string
+  handler: T
+}

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,0 +1,55 @@
+import {
+  ComponentType,
+  MessageComponentInteraction,
+  TextInputStyle,
+} from 'discord.js'
+
+import { randomUUID } from 'crypto'
+
+/**
+ * Prompt for a single text input in Discord.
+ *
+ * @param interaction - the interaction that will trigger the prompt
+ * @returns a submission object or undefined if the prompt timed out. You should reply to `submission.interaction` with a message.
+ */
+export async function prompt(
+  interaction: MessageComponentInteraction,
+  title: string,
+  label: string,
+) {
+  const promptId = randomUUID() as string
+  await interaction.showModal({
+    customId: promptId,
+    title,
+    components: [
+      {
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            customId: 'text',
+            label,
+            type: ComponentType.TextInput,
+            style: TextInputStyle.Short,
+            required: true,
+          },
+        ],
+      },
+    ],
+  })
+
+  const submitted = await interaction
+    .awaitModalSubmit({
+      time: 5 * 60000,
+      filter: (i) => i.customId === promptId,
+    })
+    .catch(() => null)
+
+  if (!submitted) {
+    return undefined
+  }
+
+  return {
+    text: submitted.fields.getTextInputValue('text'),
+    interaction: submitted,
+  }
+}


### PR DESCRIPTION
# Description

Added a feature to inspect profile.

Two utilities has been added:

- `ActionSet` — for improving buttons.
- `prompt` — for requesting text from user.

## How to invoke

- Option 1: Right click on a message &rarr; Inspect user profile

  <img width="588" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/6a8a7174-d139-43f7-bebd-63176e1b95fc">

- Option 2: Slash command

  <img width="303" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/773dfb07-6a95-4d7c-9fdf-7c246d940cb5">

- Option 3: Right click user &rarr; Inspect profile

  <img width="593" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/48f059b7-3de3-4763-b964-c9ef7514aac1">

## Usage

When inspecting user profile, it shows

- basic info
- the number of strikes the user currently has
- recent moderation log for this user
- buttons to add strike or reset strike

<img width="712" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/9263f7c1-bb00-4bf7-b270-6880d1f78e62">

When adding a strike it prompts for a reason.

<img width="519" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/9625f565-b210-45d8-93b5-e18350b6a1df">

Right now getting a strike does not do anything.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
