### PR TITLE
add active threads command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,15 +1,17 @@
 import { CommandHandlerConfig } from '../types/CommandHandlerConfig.js'
 
 import ping from './info/ping.js'
+import activeThreads from './moderators/activeThreads.js'
 import deleteAllMessage from './moderators/deleteAllMessage.js'
 import inspectProfile from './moderators/inspectProfile.js'
 import report from './moderators/report.js'
 import user from './moderators/user.js'
 
 export default [
-  ping,
+  activeThreads,
   deleteAllMessage,
   ...inspectProfile,
+  ping,
   report,
   user,
 ] satisfies CommandHandlerConfig[]

--- a/src/commands/moderators/activeThreads.ts
+++ b/src/commands/moderators/activeThreads.ts
@@ -1,12 +1,15 @@
 import {
   APIThreadChannel,
   ApplicationCommandType,
+  ComponentType,
+  MessageActionRowComponentData,
   PermissionsBitField,
   RESTGetAPIGuildThreadsResult,
   Routes,
 } from 'discord.js'
 
 import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
+import { ActionSet } from '../../utils/ActionSet.js'
 
 export default {
   data: {
@@ -24,8 +27,59 @@ export default {
     const threads = (data.threads as APIThreadChannel[])
       .slice()
       .sort((a, b) => +(a.last_message_id || 0) - +(b.last_message_id || 0))
+    const actionSet = new ActionSet()
+    const components: MessageActionRowComponentData[] = [
+      {
+        type: ComponentType.StringSelect,
+        customId: actionSet.register('select', async (selectInteraction) => {
+          if (!selectInteraction.isStringSelectMenu()) return
+          const customId = selectInteraction.values[0]
+          const resolved = actionSet.resolve({ customId })
+          if (!resolved) return
+          await resolved.handler(selectInteraction)
+        }),
+        placeholder: 'Select an action',
+        options: [
+          {
+            label: 'Generate report (unimplemented)',
+            value: actionSet.register(
+              'generate-report',
+              async (selectInteraction) => {
+                await selectInteraction.reply({
+                  content: 'Unimplemented!',
+                  ephemeral: true,
+                })
+              },
+            ),
+          },
+          {
+            label: 'Prune old threads (unimplemented)',
+            value: actionSet.register('prune', async (selectInteraction) => {
+              await selectInteraction.reply({
+                content: 'Unimplemented!',
+                ephemeral: true,
+              })
+            }),
+          },
+        ],
+      },
+    ]
     await interaction.editReply({
       content: `There are currently **${threads.length}** active threads in this server.`,
+      components: [
+        {
+          type: ComponentType.ActionRow,
+          components,
+        },
+      ],
     })
+    const action = await actionSet.awaitInChannel(
+      interaction.channel,
+      60e3,
+      interaction.user,
+    )
+    await interaction.editReply({ components: [] }).catch(console.error)
+    if (!action) return
+    await action.registeredAction.handler(action.interaction)
   },
 } satisfies CommandHandlerConfig

--- a/src/commands/moderators/activeThreads.ts
+++ b/src/commands/moderators/activeThreads.ts
@@ -37,6 +37,7 @@ export default {
         value: actionSet.register(
           'generate-report',
           async (selectInteraction) => {
+            // TODO: Implement
             await selectInteraction.reply({
               content: 'Unimplemented!',
               ephemeral: true,
@@ -46,12 +47,16 @@ export default {
       },
       {
         label: 'Prune old threads (unimplemented)',
-        value: actionSet.register('prune', async (selectInteraction) => {
-          await selectInteraction.reply({
-            content: 'Unimplemented!',
-            ephemeral: true,
-          })
-        }),
+        value: actionSet.register(
+          'prune-old-threads',
+          async (selectInteraction) => {
+            // TODO: Implement
+            await selectInteraction.reply({
+              content: 'Unimplemented!',
+              ephemeral: true,
+            })
+          },
+        ),
       },
     ]
     const components: MessageActionRowComponentData[] = [

--- a/src/commands/moderators/activeThreads.ts
+++ b/src/commands/moderators/activeThreads.ts
@@ -23,8 +23,6 @@ export default {
   ephemeral: false,
   execute: async (client, interaction) => {
     if (!interaction.guild || !interaction.isChatInputCommand()) return
-
-    // Load active threads
     const data = await getActiveThreads(client, interaction.guild)
 
     // Sort threads by last message (more recent first)

--- a/src/commands/moderators/activeThreads.ts
+++ b/src/commands/moderators/activeThreads.ts
@@ -1,0 +1,31 @@
+import {
+  APIThreadChannel,
+  ApplicationCommandType,
+  PermissionsBitField,
+  RESTGetAPIGuildThreadsResult,
+  Routes,
+} from 'discord.js'
+
+import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
+
+export default {
+  data: {
+    name: 'active-threads',
+    description: 'Get information and statistics about server threads',
+    defaultMemberPermissions: PermissionsBitField.Flags.ManageMessages,
+    type: ApplicationCommandType.ChatInput,
+  },
+  ephemeral: false,
+  execute: async (client, interaction) => {
+    if (!interaction.guild || !interaction.isChatInputCommand()) return
+    const data = (await client.rest.get(
+      Routes.guildActiveThreads(interaction.guild.id),
+    )) as RESTGetAPIGuildThreadsResult
+    const threads = (data.threads as APIThreadChannel[])
+      .slice()
+      .sort((a, b) => +(a.last_message_id || 0) - +(b.last_message_id || 0))
+    await interaction.editReply({
+      content: `There are currently **${threads.length}** active threads in this server.`,
+    })
+  },
+} satisfies CommandHandlerConfig

--- a/src/commands/moderators/activeThreads.ts
+++ b/src/commands/moderators/activeThreads.ts
@@ -28,7 +28,7 @@ export default {
     // Sort threads by last message (more recent first)
     const threads = (data.threads as APIThreadChannel[])
       .slice()
-      .sort((a, b) => +(b.last_message_id || 0) - +(a.last_message_id || 0))
+      .sort((a, b) => +(b.last_message_id ?? 0) - +(a.last_message_id ?? 0))
 
     const actionSet = new ActionSet()
     const options: SelectMenuComponentOptionData[] = [


### PR DESCRIPTION
# Description

the server has a problem with too many threads.

last night i asked a moderator about what kind of automation would be most valuable, it is: threads pruning.

<img width="672" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/b577ae5b-e8d0-4c28-8ccf-6de3cba93ad2">

this PR prepares the way to go forward. start by letting moderators check how many active threads are there.

<img width="510" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/811ab43f-4c95-4241-bb6a-49fe945ca65b">

later PR can extend this command to provide functionality to, e.g. generate a report or prune oldest threads or more.

<img width="539" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/974fa0ec-948b-4b18-9543-ef0d97a37418">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
