### PR TITLE
use type helpers

### DIFF
--- a/src/commands/info/ping.ts
+++ b/src/commands/info/ping.ts
@@ -1,6 +1,6 @@
-import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
+import { defineCommandHandler } from '../../types/defineCommandHandler.js'
 
-export default {
+export default defineCommandHandler({
   data: {
     name: 'ping',
     description: 'Ping!',
@@ -13,4 +13,4 @@ export default {
       ],
     })
   },
-} satisfies CommandHandlerConfig
+})

--- a/src/commands/moderators/deleteAllMessage.ts
+++ b/src/commands/moderators/deleteAllMessage.ts
@@ -7,9 +7,9 @@ import {
   PermissionsBitField,
 } from 'discord.js'
 
-import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
+import { defineCommandHandler } from '../../types/defineCommandHandler.js'
 
-export default {
+export default defineCommandHandler({
   data: {
     name: 'Prune messages',
     type: ApplicationCommandType.Message,
@@ -110,4 +110,4 @@ export default {
       components: [],
     })
   },
-} satisfies CommandHandlerConfig
+})

--- a/src/commands/moderators/inspectProfile.ts
+++ b/src/commands/moderators/inspectProfile.ts
@@ -5,10 +5,10 @@ import {
 } from 'discord.js'
 
 import { inspectProfile } from '../../features/profileInspector/index.js'
-import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
+import { defineCommandHandler } from '../../types/defineCommandHandler.js'
 
 export default [
-  {
+  defineCommandHandler({
     data: {
       name: 'Inspect profile',
       type: ApplicationCommandType.User,
@@ -25,8 +25,8 @@ export default [
 
       await inspectProfile({ client, interaction, member })
     },
-  },
-  {
+  }),
+  defineCommandHandler({
     data: {
       name: 'Inspect author',
       type: ApplicationCommandType.Message,
@@ -52,8 +52,8 @@ export default [
         messageContext: message,
       })
     },
-  },
-  {
+  }),
+  defineCommandHandler({
     data: {
       name: 'inspect',
       description: 'Inspect a user profile',
@@ -78,5 +78,5 @@ export default [
 
       await inspectProfile({ client, interaction, member })
     },
-  },
-] satisfies CommandHandlerConfig[]
+  }),
+]

--- a/src/commands/moderators/report.ts
+++ b/src/commands/moderators/report.ts
@@ -2,9 +2,9 @@ import { ApplicationCommandType, TextChannel } from 'discord.js'
 
 import { Environment } from '../../config.js'
 import { isUniqueConstraintViolation, prisma } from '../../prisma.js'
-import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
+import { defineCommandHandler } from '../../types/defineCommandHandler.js'
 
-export default {
+export default defineCommandHandler({
   data: {
     name: 'Report to moderator',
     type: ApplicationCommandType.Message,
@@ -89,4 +89,4 @@ export default {
       ],
     })
   },
-} satisfies CommandHandlerConfig
+})

--- a/src/commands/moderators/user.ts
+++ b/src/commands/moderators/user.ts
@@ -1,8 +1,8 @@
 import { ApplicationCommandType } from 'discord.js'
 
-import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
+import { defineCommandHandler } from '../../types/defineCommandHandler.js'
 
-export default {
+export default defineCommandHandler({
   data: {
     name: 'Show user info',
     type: ApplicationCommandType.User,
@@ -39,4 +39,4 @@ export default {
       ],
     })
   },
-} satisfies CommandHandlerConfig
+})

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,8 +1,8 @@
 import { Events } from 'discord.js'
 
-import { EventHandlerConfig } from '../types/EventHandlerConfig.js'
+import { defineEventHandler } from '../types/defineEventHandler.js'
 
-export default {
+export default defineEventHandler({
   eventName: Events.GuildMemberAdd,
   once: false,
   execute: async (_client, member) => {
@@ -10,4 +10,4 @@ export default {
       `[guildMemberAdd] "${member.user.tag}" [${member.id}] joined "${member.guild.name}" [${member.guild.id}]`,
     )
   },
-} satisfies EventHandlerConfig<Events.GuildMemberAdd>
+})

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -1,8 +1,8 @@
 import { Events } from 'discord.js'
 
-import { EventHandlerConfig } from '../types/EventHandlerConfig.js'
+import { defineEventHandler } from '../types/defineEventHandler.js'
 
-export default {
+export default defineEventHandler({
   eventName: Events.GuildMemberRemove,
   once: false,
   execute: async (_client, member) => {
@@ -10,4 +10,4 @@ export default {
       `[guildMemberRemove] "${member.user.tag}" [${member.id}] left "${member.guild.name}" [${member.guild.id}]`,
     )
   },
-} satisfies EventHandlerConfig<Events.GuildMemberRemove>
+})

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -1,8 +1,8 @@
 import { Events } from 'discord.js'
 
-import { EventHandlerConfig } from '../types/EventHandlerConfig.js'
+import { defineEventHandler } from '../types/defineEventHandler.js'
 
-export default {
+export default defineEventHandler({
   eventName: Events.GuildMemberUpdate,
   once: false,
   execute: async (_client, prev, next) => {
@@ -40,4 +40,4 @@ export default {
       )
     }
   },
-} satisfies EventHandlerConfig<Events.GuildMemberUpdate>
+})

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,8 +1,8 @@
 import { Events } from 'discord.js'
 
-import { EventHandlerConfig } from '../types/EventHandlerConfig.js'
+import { defineEventHandler } from '../types/defineEventHandler.js'
 
-export default {
+export default defineEventHandler({
   eventName: Events.InteractionCreate,
   once: false,
   execute: async (client, interaction) => {
@@ -26,4 +26,4 @@ export default {
       }
     }
   },
-} satisfies EventHandlerConfig<Events.InteractionCreate>
+})

--- a/src/events/preventEmojiSpam.ts
+++ b/src/events/preventEmojiSpam.ts
@@ -1,9 +1,9 @@
 import { Events } from 'discord.js'
 
-import { EventHandlerConfig } from '../types/EventHandlerConfig.js'
+import { defineEventHandler } from '../types/defineEventHandler.js'
 import isOnlyEmoji from '../utils/isOnlyEmoji.js'
 
-export default {
+export default defineEventHandler({
   eventName: Events.MessageCreate,
   once: false,
   execute: async (client, message) => {
@@ -16,4 +16,4 @@ export default {
       }
     }
   },
-} satisfies EventHandlerConfig<Events.MessageCreate>
+})

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,9 +1,9 @@
 import { Events } from 'discord.js'
 
 import { Environment } from '../config.js'
-import { EventHandlerConfig } from '../types/EventHandlerConfig.js'
+import { defineEventHandler } from '../types/defineEventHandler.js'
 
-export default {
+export default defineEventHandler({
   eventName: Events.ClientReady,
   once: true,
   execute: async (client) => {
@@ -35,4 +35,4 @@ export default {
       console.error('[ready] Unable to clear application commands:', error)
     }
   },
-} satisfies EventHandlerConfig<Events.ClientReady>
+})

--- a/src/types/defineCommandHandler.ts
+++ b/src/types/defineCommandHandler.ts
@@ -1,0 +1,5 @@
+import { CommandHandlerConfig } from './CommandHandlerConfig.js'
+
+export function defineCommandHandler(config: CommandHandlerConfig) {
+  return config
+}

--- a/src/types/defineEventHandler.ts
+++ b/src/types/defineEventHandler.ts
@@ -1,0 +1,9 @@
+import { ClientEvents } from 'discord.js'
+
+import { EventHandlerConfig } from './EventHandlerConfig.js'
+
+export function defineEventHandler<K extends keyof ClientEvents>(
+  config: EventHandlerConfig<K>,
+): EventHandlerConfig<K> {
+  return config
+}


### PR DESCRIPTION
# Description

by using `satisfies`

- there is more type annotation (some people prefer less type annotations. e.g. [“I love TypeScript. I try to use it as little as possible. And that's a good thing.” —Theo (2023)](https://youtu.be/Xl02L1jy53c))

- have to write the same type 2 times

  ![image](https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/9e5b488c-fd9c-4709-b7e4-a811e4baf92a)

this PR creates type utility: `defineCommandHandler`

- this reduces type annotations

- no more duplicate types

  ![image](https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/72bc8a97-d741-4606-acda-b0b34071285b)

this “define” system is adopted in many modern TS ecosystems

- Astro: `defineConfig` https://docs.astro.build/en/guides/configuring-astro/
- Playwright: `defineConfig` https://playwright.dev/docs/test-configuration
- Vite: `defineConfig` https://vitejs.dev/config/#config-intellisense

## Type of change

- [x] Refactor or other

## Screenshot

see above

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
