### PR TITLE
introduce BotContext interface

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -11,10 +11,6 @@ import { EventHandlerConfig } from './types/EventHandlerConfig.js'
 export default class Bot extends Client {
   private readonly commands = new Collection<string, CommandHandlerConfig>()
   private readonly isProduction = process.env.NODE_ENV === 'production'
-  public readonly botContext: BotContext = {
-    client: this,
-    commands: this.commands,
-  }
 
   constructor() {
     super({
@@ -25,6 +21,13 @@ export default class Bot extends Client {
         IntentsBitField.Flags.MessageContent,
       ],
     })
+  }
+
+  private createBotContext() {
+    return {
+      client: this,
+      commands: this.commands,
+    } as BotContext
   }
 
   async initAndStart() {
@@ -45,11 +48,11 @@ export default class Bot extends Client {
     for (const handler of handlers) {
       if (handler.once) {
         this.once(handler.eventName, (...args) =>
-          handler.execute(this.botContext, ...args),
+          handler.execute(this.createBotContext(), ...args),
         )
       } else {
         this.on(handler.eventName, (...args) =>
-          handler.execute(this.botContext, ...args),
+          handler.execute(this.createBotContext(), ...args),
         )
       }
     }

--- a/src/commands/info/ping.ts
+++ b/src/commands/info/ping.ts
@@ -6,7 +6,7 @@ export default defineCommandHandler({
     description: 'Ping!',
   },
   ephemeral: true,
-  execute: async (client, interaction) => {
+  execute: async ({ client }, interaction) => {
     await interaction.editReply({
       embeds: [
         { description: `ความหน่วง! ${client.ws.ping}ms`, color: 0x00ff00 },

--- a/src/commands/moderators/activeThreads.ts
+++ b/src/commands/moderators/activeThreads.ts
@@ -1,6 +1,7 @@
 import {
   APIThreadChannel,
   ApplicationCommandType,
+  Client,
   ComponentType,
   MessageActionRowComponentData,
   PermissionsBitField,
@@ -9,7 +10,6 @@ import {
   SelectMenuComponentOptionData,
 } from 'discord.js'
 
-import Bot from '../../client.js'
 import { CommandHandlerConfig } from '../../types/CommandHandlerConfig.js'
 import { ActionSet } from '../../utils/ActionSet.js'
 
@@ -21,8 +21,9 @@ export default {
     type: ApplicationCommandType.ChatInput,
   },
   ephemeral: false,
-  execute: async (client, interaction) => {
+  execute: async (botContext, interaction) => {
     if (!interaction.guild || !interaction.isChatInputCommand()) return
+    const { client } = botContext
     const data = await getActiveThreads(client, interaction.guild)
 
     // Sort threads by last message (more recent first)
@@ -96,7 +97,7 @@ export default {
   },
 } satisfies CommandHandlerConfig
 
-async function getActiveThreads(client: Bot, guild: { id: string }) {
+async function getActiveThreads(client: Client, guild: { id: string }) {
   return (await client.rest.get(
     Routes.guildActiveThreads(guild.id),
   )) as RESTGetAPIGuildThreadsResult

--- a/src/commands/moderators/deleteAllMessage.ts
+++ b/src/commands/moderators/deleteAllMessage.ts
@@ -17,7 +17,7 @@ export default defineCommandHandler({
     dmPermission: false,
   },
   ephemeral: true,
-  execute: async (client, interaction) => {
+  execute: async (botContext, interaction) => {
     if (!interaction.guild || !interaction.isContextMenuCommand()) return
 
     // Fetch reference message by target id
@@ -74,6 +74,7 @@ export default defineCommandHandler({
 
     // Delete message in all channel
     let numDeleted = 0
+    const { client } = botContext
     for (const [channelId, channel] of client.channels.cache) {
       if (channel.type === ChannelType.GuildText) {
         const messages = await channel.messages.fetch()

--- a/src/commands/moderators/inspectProfile.ts
+++ b/src/commands/moderators/inspectProfile.ts
@@ -16,14 +16,14 @@ export default [
       dmPermission: false,
     },
     ephemeral: true,
-    execute: async (client, interaction) => {
+    execute: async (botContext, interaction) => {
       if (!interaction.guild || !interaction.isContextMenuCommand()) return
 
       const userId = interaction.targetId
       const member = interaction.guild.members.cache.get(userId)
       if (!member) return
 
-      await inspectProfile({ client, interaction, member })
+      await inspectProfile(botContext, { interaction, member })
     },
   }),
   defineCommandHandler({
@@ -34,7 +34,7 @@ export default [
       dmPermission: false,
     },
     ephemeral: true,
-    execute: async (client, interaction) => {
+    execute: async (botContext, interaction) => {
       if (!interaction.guild || !interaction.isContextMenuCommand()) return
 
       const messageId = interaction.targetId
@@ -45,8 +45,7 @@ export default [
       const member = interaction.guild.members.cache.get(userId)
       if (!member) return
 
-      await inspectProfile({
-        client,
+      await inspectProfile(botContext, {
         interaction,
         member,
         messageContext: message,
@@ -68,7 +67,7 @@ export default [
       ],
     },
     ephemeral: true,
-    execute: async (client, interaction) => {
+    execute: async (botContext, interaction) => {
       if (!interaction.guild || !interaction.isChatInputCommand()) return
 
       const userId = interaction.options.getUser('user')?.id
@@ -76,7 +75,7 @@ export default [
       const member = interaction.guild.members.cache.get(userId)
       if (!member) return
 
-      await inspectProfile({ client, interaction, member })
+      await inspectProfile(botContext, { interaction, member })
     },
   }),
 ]

--- a/src/commands/moderators/report.ts
+++ b/src/commands/moderators/report.ts
@@ -10,7 +10,7 @@ export default defineCommandHandler({
     type: ApplicationCommandType.Message,
   },
   ephemeral: true,
-  execute: async (client, interaction) => {
+  execute: async (botContext, interaction) => {
     if (!interaction.guild || !interaction.isContextMenuCommand()) return
     const message = await interaction.channel?.messages.fetch(
       interaction.targetId,
@@ -68,6 +68,7 @@ export default defineCommandHandler({
       })
 
     // Send the link to the message into the mod channel
+    const { client } = botContext
     const channel = client.channels.cache.get(Environment.MOD_CHANNEL_ID)
     if (!(channel instanceof TextChannel)) return
     await channel.send(

--- a/src/commands/moderators/user.ts
+++ b/src/commands/moderators/user.ts
@@ -8,7 +8,7 @@ export default defineCommandHandler({
     type: ApplicationCommandType.User,
   },
   ephemeral: true,
-  execute: async (client, interaction) => {
+  execute: async (botContext, interaction) => {
     if (!interaction.guild || !interaction.isContextMenuCommand()) return
     const member = interaction.guild.members.cache.get(interaction.targetId)
     if (!member) return

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -5,7 +5,7 @@ import { defineEventHandler } from '../types/defineEventHandler.js'
 export default defineEventHandler({
   eventName: Events.GuildMemberAdd,
   once: false,
-  execute: async (_client, member) => {
+  execute: async (botContext, member) => {
     console.info(
       `[guildMemberAdd] "${member.user.tag}" [${member.id}] joined "${member.guild.name}" [${member.guild.id}]`,
     )

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -5,7 +5,7 @@ import { defineEventHandler } from '../types/defineEventHandler.js'
 export default defineEventHandler({
   eventName: Events.GuildMemberRemove,
   once: false,
-  execute: async (_client, member) => {
+  execute: async (botContext, member) => {
     console.info(
       `[guildMemberRemove] "${member.user.tag}" [${member.id}] left "${member.guild.name}" [${member.guild.id}]`,
     )

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -5,7 +5,7 @@ import { defineEventHandler } from '../types/defineEventHandler.js'
 export default defineEventHandler({
   eventName: Events.GuildMemberUpdate,
   once: false,
-  execute: async (_client, prev, next) => {
+  execute: async (botContext, prev, next) => {
     if (prev.nickname !== next.nickname) {
       if (!prev.nickname) {
         console.info(

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -5,10 +5,11 @@ import { defineEventHandler } from '../types/defineEventHandler.js'
 export default defineEventHandler({
   eventName: Events.InteractionCreate,
   once: false,
-  execute: async (client, interaction) => {
+  execute: async (botContext, interaction) => {
     if (interaction.isCommand()) {
       const commandName = interaction.commandName
-      const command = client.commands.get(commandName)
+      const { commands } = botContext
+      const command = commands.get(commandName)
       if (!command) return
       let bypass = true
       await interaction
@@ -19,7 +20,7 @@ export default defineEventHandler({
         console.log(
           `[Command] ${interaction.user.tag} (${interaction.user.id}) > ${interaction.commandName}`,
         )
-        await command.execute(client, interaction)
+        await command.execute(botContext, interaction)
       } catch (error) {
         console.error(error)
         await interaction.deleteReply()

--- a/src/events/preventEmojiSpam.ts
+++ b/src/events/preventEmojiSpam.ts
@@ -6,7 +6,7 @@ import isOnlyEmoji from '../utils/isOnlyEmoji.js'
 export default defineEventHandler({
   eventName: Events.MessageCreate,
   once: false,
-  execute: async (client, message) => {
+  execute: async (botContext, message) => {
     // if has only emoji -> delete message
     if (isOnlyEmoji(message.content)) {
       try {

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -19,7 +19,9 @@ export default defineEventHandler({
         throw new Error(`Guild ${Environment.GUILD_ID} not found`)
       }
       await guild.commands.set(commands_data)
-      console.info(`[ready] Guild commands registered on ${guild.name}`)
+      console.info(
+        `[ready] ${commands.size} guild commands registered on ${guild.name}`,
+      )
     } catch (error) {
       console.error('[ready] Unable to set guild commands:', error)
     }

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -6,11 +6,11 @@ import { defineEventHandler } from '../types/defineEventHandler.js'
 export default defineEventHandler({
   eventName: Events.ClientReady,
   once: true,
-  execute: async (client) => {
+  execute: async (botContext) => {
+    const { client, commands } = botContext
+
     console.log(`[ready] Now online as ${client.user?.tag}.`)
-    const commands_data = [...client.commands.values()].map(
-      (command) => command.data,
-    )
+    const commands_data = [...commands.values()].map((command) => command.data)
 
     // Set guild commands
     try {

--- a/src/features/profileInspector/index.ts
+++ b/src/features/profileInspector/index.ts
@@ -1,7 +1,6 @@
 import {
   APIEmbed,
   ButtonStyle,
-  Client,
   CommandInteraction,
   ComponentType,
   GuildMember,

--- a/src/features/profileInspector/index.ts
+++ b/src/features/profileInspector/index.ts
@@ -13,24 +13,26 @@ import { MessageComponentInteraction } from 'discord.js'
 import { UserModerationLog, UserProfile } from '@prisma/client'
 
 import { prisma } from '../../prisma.js'
+import { BotContext } from '../../types/BotContext.js'
 import { ActionSet } from '../../utils/ActionSet.js'
 import { prompt } from '../../utils/prompt.js'
 
 export interface InspectProfileOptions {
-  client: Client
   interaction: CommandInteraction
   member: GuildMember
   messageContext?: Message
 }
 
 interface InspectProfileContext {
+  botContext: BotContext
   options: InspectProfileOptions
 }
 
 export async function inspectProfile(
+  botContext: BotContext,
   options: InspectProfileOptions,
 ): Promise<void> {
-  return inspectProfileMain({ options })
+  return inspectProfileMain({ botContext, options })
 }
 
 async function inspectProfileMain(

--- a/src/types/BotContext.ts
+++ b/src/types/BotContext.ts
@@ -1,0 +1,8 @@
+import { Client, Collection } from 'discord.js'
+
+import { CommandHandlerConfig } from './CommandHandlerConfig.js'
+
+export interface BotContext {
+  readonly client: Client
+  readonly commands: Collection<string, CommandHandlerConfig>
+}

--- a/src/types/BotContext.ts
+++ b/src/types/BotContext.ts
@@ -2,7 +2,17 @@ import { Client, Collection } from 'discord.js'
 
 import { CommandHandlerConfig } from './CommandHandlerConfig.js'
 
+/**
+ * A shared context object that is passed to all command handlers.
+ */
 export interface BotContext {
+  /**
+   * A Discord.js client instance.
+   */
   readonly client: Client
+
+  /**
+   * A collection of registered command handlers.
+   */
   readonly commands: Collection<string, CommandHandlerConfig>
 }

--- a/src/types/CommandHandlerExecutor.ts
+++ b/src/types/CommandHandlerExecutor.ts
@@ -1,8 +1,8 @@
 import { Awaitable, CommandInteraction } from 'discord.js'
 
-import type Bot from '../client.js'
+import { BotContext } from './BotContext.js'
 
 export type CommandHandlerExecutor = (
-  client: Bot,
+  botContext: BotContext,
   interaction: CommandInteraction,
 ) => Awaitable<void>

--- a/src/types/EventHandlerExecutor.ts
+++ b/src/types/EventHandlerExecutor.ts
@@ -1,7 +1,7 @@
 import { Awaitable, ClientEvents } from 'discord.js'
 
-import type Bot from '../client.js'
+import { BotContext } from './BotContext.js'
 
 export type EventHandlerExecutor<K extends keyof ClientEvents> = (
-  ...args: [Bot, ...ClientEvents[K]]
+  ...args: [botContext: BotContext, ...args: ClientEvents[K]]
 ) => Awaitable<void>


### PR DESCRIPTION
# Description

this PR introduces a `BotContext` interface

- it removes cyclic dependency: `client.ts` &rarr; `CommandHandlerConfig.ts` &rarr; `CommandHandlerExecutor.ts` &rarr; `client.ts`

- we can send different context to different event handler. for example, in the future we can add debugging facilities or more structured logging.

## Type of change

- [x] Refactor or other

## Screenshot

N/A, refactor only, no change in behavior

application runs properly

<img width="624" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/4c419f1f-2708-4044-b304-4858107dc962">

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
