### PR TITLE
HOTFIX: disable emoji deletion for now

### DIFF
--- a/src/events/preventEmojiSpam.ts
+++ b/src/events/preventEmojiSpam.ts
@@ -10,7 +10,7 @@ export default defineEventHandler({
     // if has only emoji -> delete message
     if (isOnlyEmoji(message.content)) {
       try {
-        await message.delete()
+        // await message.delete()
       } catch (err) {
         console.error(err)
       }

--- a/src/events/preventEmojiSpam.ts
+++ b/src/events/preventEmojiSpam.ts
@@ -10,6 +10,7 @@ export default defineEventHandler({
     // if has only emoji -> delete message
     if (isOnlyEmoji(message.content)) {
       try {
+        // Disabling for now due to #99 - bot erroneously deleting messages with only number
         // await message.delete()
       } catch (err) {
         console.error(err)

--- a/test/spec/utils/isOnlyEmoji.spec.ts
+++ b/test/spec/utils/isOnlyEmoji.spec.ts
@@ -4,14 +4,14 @@ import isOnlyEmoji from '../../../src/utils/isOnlyEmoji'
 
 describe('isOnlyEmoji', () => {
   it.each([{ msg: '🫠' }, { msg: '🅰️' }, { msg: '🅾' }, { msg: '<:test:000>' }])(
-    'should match emoji',
+    'should match emoji ($msg)',
     async ({ msg }) => {
       expect(isOnlyEmoji(msg)).toBeTruthy()
     },
   )
 
   it.each([{ msg: '' }, { msg: 'hello' }, { msg: 'a' }, { msg: '<html>' }])(
-    'should not match emoji',
+    'should not match emoji ($msg)',
     async ({ msg }) => {
       expect(isOnlyEmoji(msg)).toBeFalsy()
     },

--- a/test/spec/utils/isOnlyEmoji.spec.ts
+++ b/test/spec/utils/isOnlyEmoji.spec.ts
@@ -16,4 +16,12 @@ describe('isOnlyEmoji', () => {
       expect(isOnlyEmoji(msg)).toBeFalsy()
     },
   )
+
+  it('should not match emoji with text', async () => {
+    expect(isOnlyEmoji('hello 🫠')).toBeFalsy()
+  })
+
+  it.todo('should not match messages with only numbers', async () => {
+    expect(isOnlyEmoji('1 2 3')).toBeFalsy()
+  })
 })


### PR DESCRIPTION
# Description

the bot deletes messages with only numbers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshot

<img width="519" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/309854bd-1acb-4efd-bace-3a6d3e8a8b41">

<img width="757" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/68eef90f-0590-4ac6-bac5-1994fa9fb5f9">

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
