### PR TITLE
thread analysis

### DIFF
--- a/src/features/threadPruner/getActiveThreads.ts
+++ b/src/features/threadPruner/getActiveThreads.ts
@@ -1,0 +1,16 @@
+import {
+  APIThreadChannel,
+  Client,
+  RESTGetAPIGuildThreadsResult,
+  Routes,
+} from 'discord.js'
+
+export async function getActiveThreads(
+  client: Pick<Client, 'rest'>,
+  guild: { id: string },
+) {
+  const result = (await client.rest.get(
+    Routes.guildActiveThreads(guild.id),
+  )) as RESTGetAPIGuildThreadsResult
+  return result.threads as APIThreadChannel[]
+}

--- a/src/features/threadPruner/getThreadStats.ts
+++ b/src/features/threadPruner/getThreadStats.ts
@@ -1,0 +1,64 @@
+import { APIThreadChannel, SnowflakeUtil } from 'discord.js'
+
+export interface PruningCriteria {
+  name: string
+  threadIds: string[]
+}
+
+export function getThreadStats(threads: APIThreadChannel[]) {
+  threads = Array.from(threads).sort(
+    (a, b) => +(b.last_message_id ?? 0) - +(a.last_message_id ?? 0),
+  )
+
+  // const createPruningCriteria = (
+  //   name: string,
+  //   filter: (thread: APIThreadChannel, index: number) => boolean,
+  // ) => {
+  //   return {
+  //     name,
+  //     threadIds: threads.filter(filter).map((t) => t.id),
+  //   }
+  // }
+  // const olderThan = (ms: number) => (thread: APIThreadChannel) => {
+  //   const timestamp = thread.last_message_id
+  //     ? SnowflakeUtil.timestampFrom(thread.last_message_id)
+  //     : Infinity
+  //   return Date.now() - timestamp > ms
+  // }
+  // const bottom = (count: number) => (_: APIThreadChannel, index: number) =>
+  //   index >= threads.length - count
+  // return {
+  //   pruningCriteria: [
+  //     createPruningCriteria('older than 1 hour', olderThan(3600e3 * 1)),
+  //     createPruningCriteria('older than 3 hours', olderThan(3600e3 * 3)),
+  //     createPruningCriteria('older than 6 hours', olderThan(3600e3 * 6)),
+  //     createPruningCriteria('older than 24 hours', olderThan(3600e3 * 24)),
+  //     createPruningCriteria('older than 48 hours', olderThan(3600e3 * 48)),
+  //     createPruningCriteria('older than 72 hours', olderThan(3600e3 * 72)),
+  //     createPruningCriteria('bottom 100', bottom(100)),
+  //   ],
+  // }
+
+  let pruningCriteria: PruningCriteria[] = []
+  for (const h of [1, 3, 6, 24, 48, 72]) {
+    const name = `Prune threads with last message older than ${h}h`
+    const threadIds = threads
+      .filter((thread) => {
+        const timestamp = thread.last_message_id
+          ? SnowflakeUtil.timestampFrom(thread.last_message_id)
+          : Infinity
+        return Date.now() - timestamp > 3600e3 * h
+      })
+      .map((t) => t.id)
+    pruningCriteria.push({ name, threadIds })
+  }
+  for (const n of [100]) {
+    const name = `Prune bottom ${n} threads`
+    const threadIds = threads
+      .filter((_, index) => index >= threads.length - n)
+      .map((t) => t.id)
+    pruningCriteria.push({ name, threadIds })
+  }
+  pruningCriteria = pruningCriteria.filter((c) => c.threadIds.length > 0)
+  return { pruningCriteria }
+}

--- a/src/features/threadPruner/index.ts
+++ b/src/features/threadPruner/index.ts
@@ -1,0 +1,2 @@
+export * from './getActiveThreads.js'
+export * from './getThreadStats.js'

--- a/src/features/threadPruner/scripts/showThreadStats.ts
+++ b/src/features/threadPruner/scripts/showThreadStats.ts
@@ -1,0 +1,20 @@
+import { REST } from 'discord.js'
+
+import { Environment } from '../../../config.js'
+import { getActiveThreads } from '../getActiveThreads.js'
+import { getThreadStats } from '../getThreadStats.js'
+
+const rest = new REST().setToken(Environment.BOT_TOKEN)
+const activeThreads = await getActiveThreads(
+  { rest },
+  { id: Environment.GUILD_ID },
+)
+
+const threadStats = getThreadStats(activeThreads)
+
+for (const item of threadStats.pruningCriteria) {
+  const percent = Math.round(
+    (item.threadIds.length / activeThreads.length) * 100,
+  )
+  console.log(`- ${item.name}: ${item.threadIds.length} (${percent}%)`)
+}


### PR DESCRIPTION
# Description

this pr adds thread analysis. it shows how many threads are older than 1, 3, 6, 24, 48, 72 hours

still not implemented pruning logic

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor or other

## Screenshot

<img width="534" alt="image" src="https://github.com/creatorsgarten/kaogeek-discord-bot/assets/193136/da3c3fcc-e805-4161-8013-6362af795e75">

```sh
pnpm tsx src/features/threadPruner/scripts/showThreadStats.ts
```

test on Kaogeek server:

output:

```
- Prune threads with last message older than 1h: 531 (98%)
- Prune threads with last message older than 3h: 512 (94%)
- Prune threads with last message older than 6h: 489 (90%)
- Prune threads with last message older than 24h: 407 (75%)
- Prune threads with last message older than 48h: 298 (55%)
- Prune threads with last message older than 72h: 217 (40%)
- Prune bottom 100 threads: 100 (18%)
```


# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
